### PR TITLE
Update BC government GitHub orgs documentation link

### DIFF
--- a/templates/cm_app_config_web.yaml.j2
+++ b/templates/cm_app_config_web.yaml.j2
@@ -22,7 +22,7 @@ data:
 
     We’ll ask you to:
     - Provide the GitHub ID of anyone you wish to add. If you don’t have a GitHub ID, you can [create one here](https://github.com) 
-    - Indicate whether this GitHub ID needs to be a part of BCGov or BCDevOps (you can join both if you wish). [Read about these orgs here](https://developer.gov.bc.ca/User-access-into-Github-or-Openshift).
+    - Indicate whether this GitHub ID needs to be a part of BCGov or BCDevOps (you can join both if you wish). [Read about BC Government organizations in GitHub](https://beta-docs.developer.gov.bc.ca/bc-government-organizations-in-github/).
 
 
 


### PR DESCRIPTION
Just Ask has a link to a retired DevHub page explaining the differences in BC GitHub organizations:

<img width="1840" alt="Just Ask screenshot" src="https://user-images.githubusercontent.com/25143706/196532006-d3b6357f-17d3-4382-b4e6-33062e212505.png">

This [legacy page has been retired](https://developer.gov.bc.ca/User-access-into-Github-or-Openshift) and doesn't contain any useful information for users.

This pull request updates this link to point to the [BC Government organizations in GitHub page](https://beta-docs.developer.gov.bc.ca/bc-government-organizations-in-github/) on the Private Cloud technical documentation site, which is the best current target for this link.