### PR TITLE
DEVX-1562 Remove BCDevOps from just ask

### DIFF
--- a/templates/cm_app_config_api.yaml.j2
+++ b/templates/cm_app_config_api.yaml.j2
@@ -29,7 +29,7 @@ data:
       "AUDITOR": [
         {
           "kind": "GithubTeam",
-          "team": "platform-services-just-ask-auditors",
+          "team": "just-ask-auditors",
           "organization": "bcgov"
         }
       ]

--- a/templates/cm_app_config_api.yaml.j2
+++ b/templates/cm_app_config_api.yaml.j2
@@ -5,19 +5,13 @@ data:
   config.json: |-
     {
       "orgs": [
-        "bcgov",
-        "bcdevops"
+        "bcgov"
       ],
-      "primaryOrg": "bcdevops"
+      "primaryOrg": "bcgov"
     }
   role-mappers.json: |-
     {
       "APPROVER": [
-        {
-          "kind": "OrgRole",
-          "role": "admin",
-          "organization": "bcdevops"
-        },
         {
           "kind": "OrgRole",
           "role": "admin",
@@ -30,18 +24,13 @@ data:
           "kind": "OrgRole",
           "role": "member",
           "organization": "bcgov"
-        },
-        {
-          "kind": "OrgRole",
-          "role": "member",
-          "organization": "bcdevops"
         }
        ],
       "AUDITOR": [
         {
           "kind": "GithubTeam",
           "team": "platform-services-just-ask-auditors",
-          "organization": "bcdevops"
+          "organization": "bcgov"
         }
       ]
     }


### PR DESCRIPTION
The following was done:

- Removed bcdevops org
- Made bcgov the primaryOrg
- Made a new team in the bcgov org for audit control

Outside of this PR, the following was also done:

- New Just Ask GitHub App was installed in bcgov
- `test` environment was added to this repo in b8e5177. Secrets were added to the test environment that contain the new GitHub appID etc. This was done so testing of the new app could be done in the test namespace without affecting prod.  The secrets used by PROD will need to be updated once testing has passed.