### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: On Deployment Created
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/bcgov-just-ask/security/code-scanning/1](https://github.com/bcgov/bcgov-just-ask/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Since the workflow does not appear to interact with the repository contents or perform other GitHub API operations, we will set `contents: read` as the minimal permission. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents, adhering to the principle of least privilege.

The `permissions` block will be added at the root level of the workflow, just below the `name` field, so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
